### PR TITLE
K8S-10065: update charts to 1.2.0 for rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 We required a reliable way to create unhealthy states in our clusters to showcase [Dynatrace](https://www.dynatrace.com)'s monitoring capabilities.\
 Feedback and contributions are welcome.
 
-| Problem Pattern                            | Description                                                                               |
-|--------------------------------------------|-------------------------------------------------------------------------------------------|
-| [exceeded-quota](exceeded-quota/README.md) | a deployment that violates a specified resource quota when scaled up                      |
-| [frequent-restarts](frequent-restarts/README.md)                         | periodic restart of a ingress-nginx pod                                                   |
-| [node-pressure](node-pressure/README.md)                             | allocate RAM on a specified node using stress-ng until the system is out-of-memory |
-| [pending-pod](pending-pod/README.md)                               | pods in pending state due to insufficient resources            |
-| [pvc-out-of-space](pvc-out-of-space/README.md)                          | container registry that will be filled up over time to exceed the limit on the pvc        |
-| [terminating-pod](terminating-pod/README.md)                           | pod in terminating state due to a misconfigured finalizer                                 |
+| Problem Pattern                                  | Description                                                                        |
+|--------------------------------------------------|------------------------------------------------------------------------------------|
+| [exceeded-quota](exceeded-quota/README.md)       | a deployment that violates a specified resource quota when scaled up               |
+| [frequent-restarts](frequent-restarts/README.md) | periodic restart of a ingress-nginx pod                                            |
+| [node-pressure](node-pressure/README.md)         | allocate RAM on a specified node using stress-ng until the system is out-of-memory |
+| [pending-pod](pending-pod/README.md)             | pods in pending state due to insufficient resources                                |
+| [pvc-out-of-space](pvc-out-of-space/README.md)   | container registry that will be filled up over time to exceed the limit on the pvc |
+| [terminating-pod](terminating-pod/README.md)     | pod in terminating state due to a misconfigured finalizer                          |
 
 New problem-patterns will be added over time and we plan to improve and adjust all of them in the near future.\
 Feel free to share ideas with us!

--- a/exceeded-quota/Chart.yaml
+++ b/exceeded-quota/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: a deployment that violates a specified resource quota when scaled up
 name: exceeded-quota
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/exceeded-quota/README.md
+++ b/exceeded-quota/README.md
@@ -1,10 +1,10 @@
 # Problem-Pattern 'exceeded-quota'
-![ChartVersion](https://img.shields.io/badge/ChartVersion-1.1.0-informational?style=flat)
+![ChartVersion](https://img.shields.io/badge/ChartVersion-1.2.0-informational?style=flat)
 
 ## Overview
 This chart will impose a `ResourceQuota` in the defined `Namespace`. The deployment will be scaled up using a `CronJob` to exceed the given quota.\
-By default the first scale up (2->3) will happen at 02:00 UTC, the second (3->4 replicas) at 05:15 UTC - this will exceed the `ResourceQuota`. 
-At 05:30 UTC the `Deployment` will be scaled back to 2 replicas.\
+By default the first scale up (2->3) will happen at 02:00 UTC, the second (3->4 replicas) at 02:20 UTC - this will exceed the `ResourceQuota`. 
+At 02:30 UTC the `Deployment` will be scaled back to 2 replicas.\
 These schedules can be adjusted in [cronjobs.yaml](templates/cronjobs.yaml). 
 
 The `CronJob` and its required `ServiceAccount` will be deployed in the default "problem-patterns" `Namespace` (unless updated in the [values.yaml](values.yaml)).\

--- a/exceeded-quota/templates/cronjobs.yaml
+++ b/exceeded-quota/templates/cronjobs.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: exceeded-quota-scale-up-3
+  name: {{ .Release.Name }}-scale-up-3
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -19,7 +19,7 @@ spec:
             args:
               - scale
               - deployment
-              - exceeded-quota
+              - {{ .Values.faultInjection.nameOverride }}
               - --replicas=3
               - --namespace={{ .Release.Namespace }}
 
@@ -27,7 +27,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: exceeded-quota-scale-up-4
+  name: {{ .Release.Name }}-scale-up-4
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -45,7 +45,7 @@ spec:
             args:
               - scale
               - deployment
-              - exceeded-quota
+              - {{ .Values.faultInjection.nameOverride }}
               - --replicas=4
               - --namespace={{ .Release.Namespace }}
 
@@ -53,7 +53,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: exceeded-quota-scale-down
+  name: {{ .Release.Name }}-scale-down
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -71,6 +71,6 @@ spec:
             args:
               - scale
               - deployment
-              - exceeded-quota
+              - {{ .Values.faultInjection.nameOverride }}
               - --replicas=2
               - --namespace={{ .Release.Namespace }}

--- a/exceeded-quota/templates/deployment.yaml
+++ b/exceeded-quota/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: exceeded-quota
+  name: {{ .Values.faultInjection.nameOverride }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
@@ -14,8 +14,8 @@ spec:
         demo: exceeded-quota
     spec:
       containers:
-      - name: tomcat
-        image: tomcat
-        resources:
-          requests:
-            memory: 100Mi
+        - name: {{ .Values.faultInjection.nameOverride }}
+          image: busybox
+          command: [ "sh", "-c", "sleep infinity" ]
+          resources:
+{{ toYaml .Values.busybox.resources | indent 12 }}

--- a/exceeded-quota/templates/rbac.yaml
+++ b/exceeded-quota/templates/rbac.yaml
@@ -15,7 +15,7 @@ rules:
   resources:
   - deployments/scale
   resourceNames:
-  - exceeded-quota
+  - {{ .Values.faultInjection.nameOverride }}
   verbs:
   - patch
 ---

--- a/exceeded-quota/templates/resource_quota.yaml
+++ b/exceeded-quota/templates/resource_quota.yaml
@@ -1,8 +1,11 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: exceeded-quota
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   hard:
-    requests.memory: 310Mi
+    limits.cpu: 310m
+    limits.memory: 1Gi
+    requests.cpu: 310m
+    requests.memory: 1Gi

--- a/exceeded-quota/values.yaml
+++ b/exceeded-quota/values.yaml
@@ -1,6 +1,16 @@
+busybox:
+  resources:
+    limits:
+      cpu: "100m"
+      memory: "100Mi"
+    requests:
+      cpu: "100m"
+      memory: "100Mi"
+
 faultInjection:
+  nameOverride: events-processor
   namespace: problem-patterns
   schedule:
-    scaleDown: "30 5 * * *"
+    scaleDown: "30 2 * * *"
     scaleUpTo3: "0 2 * * *"
-    scaleUpTo4: "15 5 * * *"
+    scaleUpTo4: "20 2 * * *"

--- a/frequent-restarts/Chart.yaml
+++ b/frequent-restarts/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 dependencies:
   - name: ingress-nginx
+    alias: ingress
     version: "4.10.1"
     repository: "https://kubernetes.github.io/ingress-nginx"
 description: periodic restart of a ingress-nginx pod
 name: frequent-restarts
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/frequent-restarts/README.md
+++ b/frequent-restarts/README.md
@@ -1,5 +1,5 @@
 # Problem-Pattern 'frequent-restarts'
-![ChartVersion](https://img.shields.io/badge/ChartVersion-1.1.0-informational?style=flat)
+![ChartVersion](https://img.shields.io/badge/ChartVersion-1.2.0-informational?style=flat)
 
 ## Overview
 This chart will deploy `ingress-nginx` in the defined`Namespace`. The controller will be restarted by a `CronJob`.\

--- a/frequent-restarts/templates/cronjobs.yaml
+++ b/frequent-restarts/templates/cronjobs.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: frequent-restarts-kill-nginx
+  name: {{ .Release.Name }}-kill-ingress-nginx
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   concurrencyPolicy: Forbid
@@ -21,4 +21,4 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  kubectl exec --namespace {{ .Release.Namespace }} deployment/{{ .Release.Name }}-ingress-nginx-controller -- pkill /nginx-ingress-controller
+                  kubectl exec --namespace {{ .Release.Namespace }} deployment/{{ .Values.faultInjection.nameOverride }}-controller -- pkill /nginx-ingress-controller

--- a/frequent-restarts/values.yaml
+++ b/frequent-restarts/values.yaml
@@ -1,4 +1,16 @@
 faultInjection:
+  nameOverride: "ingress-dev"
   namespace: problem-patterns
   schedule:
     killProcess: "0,1,2 10 * * *"
+
+ingress:
+  controller:
+    admissionWebhooks:
+      enabled: false
+    ingressClassResource:
+      name: frequent-restarts-nginx
+      default: false
+    service:
+      enabled: false
+  fullnameOverride: "ingress-dev"

--- a/node-pressure/Chart.yaml
+++ b/node-pressure/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: allocate RAM on a specified node using stress-ng until the system is out-of-memory
 name: node-pressure
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/node-pressure/README.md
+++ b/node-pressure/README.md
@@ -1,5 +1,5 @@
 # Problem-Pattern 'node-pressure'
-![ChartVersion](https://img.shields.io/badge/ChartVersion-1.1.0-informational?style=flat)
+![ChartVersion](https://img.shields.io/badge/ChartVersion-1.2.0-informational?style=flat)
 
 ## Overview
 This chart will deploy a pod running a [script](files/script.sh) that fills up the hosts memory using `stress-ng`.\
@@ -8,8 +8,11 @@ By default we will fill up to 16GB of memory (`--vm-bytes`) with a single worker
 All components will be deployed to the specified `--namespace` in the `helm upgrade --install` command.
 
 ### Use-Case
-In this demo we are allocating memory on the node to the point where the OS will get into a out-of-memory (OOM) situation. The kernel will kill the workload as it's identified as the problem source automatically.\
-The process will be spawned over and over again and will cause a continuous oom-kill, respawn loop. This behaviour can potentially raise an alert if the workload is monitored.
+In this demo we are allocating memory on the node to the point where the OS will get into a out-of-memory (OOM) situation. The reaction is then dependent on the Kubernetes flavor.\
+We have tested this on AKS and EKS and have noticed slightly different behaviours. This can potentially raise an alert if the workload is monitored.
+#### AKS Cluster - Example
+The kernel will kill the workload as it's identified as the problem source automatically.\
+The process will be spawned over and over again and will cause a continuous oom-kill, respawn loop. 
 
 ```shell
 $ kubectl describe node -l demo=node-pressure
@@ -20,7 +23,21 @@ Warning  SystemOOM   3m57s                   kubelet         System OOM encounte
 Warning  OOMKilling  3m56s                   kernel-monitor  Out of memory: Killed process 3103923 (stress-ng-vm) total-vm:15791416kB, anon-rss:14369596kB, file-rss:4kB, shmem-rss:36kB, UID:0 pgtables:28184kB oom_score_adj:1000
 Warning  SystemOOM   2m13s (x16 over 3m50s)  kubelet         (combined from similar events): System OOM encountered, victim process: stress-ng-vm, pid: 3106306
 Warning  OOMKilling  2m13s (x16 over 3m50s)  kernel-monitor  (combined from similar events): Out of memory: Killed process 3106306 (stress-ng-vm) total-vm:15791416kB, anon-rss:14360328kB, file-rss:4kB, shmem-rss:36kB, UID:0 pgtables:28168kB oom_score_adj:1000
-  ```
+```
+#### EKS cluster - Example
+The node's `MemoryPressure` condition will be set to `True` and a taint is set automatically: `node.kubernetes.io/memory-pressure:NoSchedule`\
+Theoretically this prevents any further scheduling until the unhealthy status is resolved. We are queueing our workload nonetheless by actively tolerating the taint for our workload.\
+Once the node has recovered itself, the condition will be set to `False` and the taint is removed. Our workload is scheduled and will put the node under pressure again.
+```shell
+$ kubectl describe node -l demo=node-pressure
+[...]
+Events:
+Type     Reason                     Age                From     Message
+  ----     ------                     ----               ----     -------
+Normal   NodeHasSufficientMemory    10m (x5 over 46d)  kubelet  Node <DEDUCTED>.eu-central-1.compute.internal status is now: NodeHasSufficientMemory
+Warning  EvictionThresholdMet       85s (x4 over 27m)  kubelet  Attempting to reclaim memory
+Normal   NodeHasInsufficientMemory  75s (x4 over 26m)  kubelet  Node <DEDUCTED>.eu-central-1.compute.internal status is now: NodeHasInsufficientMemory
+```
 
 ## Installation
 Simply run a `helm upgrade` command from the root of this repository:

--- a/node-pressure/templates/statefulset.yaml
+++ b/node-pressure/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: node-pressure
+  name: {{ .Values.faultInjection.nameOverride }}
 spec:
   selector:
     matchLabels:
@@ -14,42 +14,46 @@ spec:
       annotations:
         oneagent.dynatrace.com/inject: "false"
     spec:
+      containers:
+        - name: {{ .Values.faultInjection.nameOverride }}
+          image: alpine
+          command:
+            - sh
+            - /script/script.sh
+          volumeMounts:
+            - name: script
+              mountPath: /script
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "ps -ef | grep stress | grep -v grep"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "ps -ef | grep stress | grep -v grep"
+            initialDelaySeconds: 120
+            periodSeconds: 5
 {{- if .Values.faultInjection.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.faultInjection.nodeSelector | indent 8 }}
 {{- end }}
       serviceAccountName: node-pressure
+{{- if .Values.faultInjection.tolerations }}
+      tolerations:
+{{ toYaml .Values.faultInjection.tolerations | indent 6 }}
+{{- end}}
       volumes:
       - name: script
         configMap:
           name: script
-      containers:
-      - name: node-pressure
-        image: alpine
-        command:
-        - sh
-        - /script/script.sh
-        volumeMounts:
-        - name: script
-          mountPath: /script
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - "ps -ef | grep stress | grep -v grep"
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - "ps -ef | grep stress | grep -v grep"
-          initialDelaySeconds: 120
-          periodSeconds: 5

--- a/node-pressure/values.yaml
+++ b/node-pressure/values.yaml
@@ -1,3 +1,8 @@
 faultInjection:
+  nameOverride: parallel-processing
   nodeSelector:
     demo: node-pressure
+  tolerations:
+  - key: "node.kubernetes.io/memory-pressure"
+    operator: "Exists"
+    effect: "NoSchedule"

--- a/pending-pod/Chart.yaml
+++ b/pending-pod/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: pods in pending state due to insufficient resources
 name: pending-pod
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/pending-pod/README.md
+++ b/pending-pod/README.md
@@ -1,5 +1,5 @@
 # Problem-Pattern 'pending-pod'
-![ChartVersion](https://img.shields.io/badge/ChartVersion-1.1.0-informational?style=flat)
+![ChartVersion](https://img.shields.io/badge/ChartVersion-1.2.0-informational?style=flat)
 
 ## Overview
 This chart will install a `Deployment` that results in a pending-pod situation by scaling beyond available resources. Requests and limits can be customized in [values.yaml](values.yaml). A `CronJob` takes care of scaling the deployment up and down accordingly.\
@@ -16,7 +16,7 @@ In order to make this a valid demo, you will need to ensure the requests/replica
 
 ### Use-Case
 In this demo we are creating a pending-pod scenario by scaling our workload beyond the node's available resources. The scaling is scheduled to happen 3 times a day with 4 hours in between scale up and scale down.\
-With this we can ensure a re-occuring issue which can be used to potentially raise an alert if the workload is monitored.
+With this we can ensure a re-occurring issue which can be used to potentially raise an alert if the workload is monitored.
 ```shell
 $ kubectl get pods -n pending-pod
 NAME                            READY   STATUS    RESTARTS   AGE

--- a/pending-pod/templates/cronjobs.yaml
+++ b/pending-pod/templates/cronjobs.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.busybox.nameOverride }}-scale-up
+  name: {{ .Release.Name }}-scale-up
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -18,14 +18,14 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  kubectl scale deployment {{ .Values.busybox.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.max }}
+                  kubectl scale deployment {{ .Values.faultInjection.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.max }}
           restartPolicy: OnFailure
           serviceAccountName: pending-pod
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Values.busybox.nameOverride }}-scale-down
+  name: {{ .Release.Name }}-scale-down
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -42,6 +42,6 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  kubectl scale deployment {{ .Values.busybox.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.min }}
+                  kubectl scale deployment {{ .Values.faultInjection.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.min }}
           restartPolicy: OnFailure
           serviceAccountName: pending-pod

--- a/pending-pod/templates/deployments.yaml
+++ b/pending-pod/templates/deployments.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.busybox.nameOverride }}
+  name: {{ .Values.faultInjection.nameOverride }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.faultInjection.replicas.min }}
@@ -16,7 +16,7 @@ spec:
         demo: pending-pod
     spec:
       containers:
-        - name: {{ .Values.busybox.nameOverride }}
+        - name: {{ .Values.faultInjection.nameOverride }}
           image: busybox
           command: ["sh", "-c", "sleep infinity"]
           resources:

--- a/pending-pod/values.yaml
+++ b/pending-pod/values.yaml
@@ -1,20 +1,20 @@
 busybox:
-  nameOverride: mail-service
   resources:
-    requests:
-      memory: "128Mi"
-      cpu: "450m"
     limits:
-      memory: "128Mi"
       cpu: "450m"
+      memory: "128Mi"
+    requests:
+      cpu: "450m"
+      memory: "128Mi"
 
 faultInjection:
+  nameOverride: mail-service
   namespace: problem-patterns
   nodeSelector:
     demo: pending-pod
   replicas:
-    max: 5
-    min: 4
+    max: 4
+    min: 3
   schedule:
-    scaleUp: "0 0,8,16 * * *" # Daily @ 00:00, 08:00 & 16:00
-    scaleDown: "0 4,12,20 * * *" # Daily @ 04:00, 12:00 & 20:00
+    scaleUp: "0 14 * * *" # Daily @ 00:00, 08:00 & 16:00
+    scaleDown: "40 14 * * *" # Daily @ 04:00, 12:00 & 20:00

--- a/pvc-out-of-space/Chart.yaml
+++ b/pvc-out-of-space/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 description: container registry that will be filled up over time to exceed the limit on the pvc
 name: pvc-out-of-space
 type: application
-version: "1.1.0"
+version: "1.2.0"

--- a/pvc-out-of-space/README.md
+++ b/pvc-out-of-space/README.md
@@ -1,5 +1,5 @@
 # Problem-Pattern 'pvc-out-of-space'
-![ChartVersion](https://img.shields.io/badge/ChartVersion-1.1.0-informational?style=flat)
+![ChartVersion](https://img.shields.io/badge/ChartVersion-1.2.0-informational?style=flat)
 
 ## Overview
 This chart will deploy `zot` (container registry) in the defined `Namespace`. Using `kaniko` in a `CronJob` we will push an image every 15 minutes until the `PersistentVolume` is full.\

--- a/pvc-out-of-space/files/delete_images.sh
+++ b/pvc-out-of-space/files/delete_images.sh
@@ -8,7 +8,7 @@ chmod 755 regctl
 echo "done"
 
 echo "Listing images..."
-images="$(./regctl tag list "zot.${NAMESPACE}:5000/big-image" --host "user=admin,pass=$REG_PW,reg=zot.${NAMESPACE}:5000,tls=disabled")"
+images="$(./regctl tag list "${REGISTRY}.${NAMESPACE}:5000/big-image" --host "user=admin,pass=$REG_PW,reg=${REGISTRY}.${NAMESPACE}:5000,tls=disabled")"
 echo "$images"
 echo "done"
 
@@ -16,7 +16,7 @@ echo "Deleting images..."
 for image in $images;
 do
   echo "Deleting big-image:${image}..."
-  ./regctl tag delete "zot.${NAMESPACE}:5000/big-image:${image}" --host "user=admin,pass=$REG_PW,reg=zot.${NAMESPACE}:5000,tls=disabled"
+  ./regctl tag delete "${REGISTRY}.${NAMESPACE}:5000/big-image:${image}" --host "user=admin,pass=$REG_PW,reg=${REGISTRY}.${NAMESPACE}:5000,tls=disabled"
   echo "deleted big-image:${image}"
 done
 echo "done deleting images"

--- a/pvc-out-of-space/templates/cronjobs.yaml
+++ b/pvc-out-of-space/templates/cronjobs.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: kaniko-big-image-push
+  name: {{ .Release.Name }}-kaniko-big-image-push
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -22,7 +22,7 @@ spec:
                 - "--skip-tls-verify"
                 - "--build-arg=FILE_SIZE=$(FILE_SIZE)"
                 - "--dockerfile=Containerfile"
-                - "--destination=zot.{{ .Release.Namespace }}:5000/big-image:$(IMAGE_NAME)"
+                - "--destination={{ .Values.faultInjection.nameOverride }}.{{ .Release.Namespace }}:5000/big-image:$(IMAGE_NAME)"
               env:
                 - name: IMAGE_NAME
                   valueFrom:
@@ -53,7 +53,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: delete-tags
+  name: {{ .Release.Name }}-delete-tags
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
@@ -76,6 +76,8 @@ spec:
                       key: admin_password
                 - name: NAMESPACE
                   value: {{ .Release.Namespace }}
+                - name: REGISTRY
+                  value: {{ .Values.faultInjection.nameOverride }}
               args:
                 - "sh"
                 - "-c"

--- a/pvc-out-of-space/templates/secrets.yaml
+++ b/pvc-out-of-space/templates/secrets.yaml
@@ -34,7 +34,7 @@ stringData:
   config.json: |
     {
       "auths": {
-        "zot.{{ .Release.Namespace }}:5000": {
+        "{{ .Values.faultInjection.nameOverride }}.{{ .Release.Namespace }}:5000": {
           "username": "admin",
           "password": "{{ $password }}"
         }

--- a/pvc-out-of-space/values.yaml
+++ b/pvc-out-of-space/values.yaml
@@ -1,11 +1,12 @@
 faultInjection:
+  nameOverride: zot-registry
   namespace: problem-patterns
   schedule:
     bigImagePush: "*/15 * * * *" # every 15th minute
     deleteTags: "45 23 * * *" # 23:45 each day
 
 zot:
-  fullnameOverride: zot
+  fullnameOverride: zot-registry
   service:
     type: ClusterIP
   mountConfig: true

--- a/terminating-pod/Chart.yaml
+++ b/terminating-pod/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: pod in terminating state due to a misconfigured finalizer
 name: terminating-pod
 type: application
-version: 1.1.0
+version: 1.2.0

--- a/terminating-pod/README.md
+++ b/terminating-pod/README.md
@@ -1,5 +1,5 @@
 # Problem-Pattern 'terminating-pod'
-![ChartVersion](https://img.shields.io/badge/ChartVersion-1.1.0-informational?style=flat)
+![ChartVersion](https://img.shields.io/badge/ChartVersion-1.2.0-informational?style=flat)
 
 ## Overview
 This chart will create a simple `Deployment` with a `nginx` workload in the defined `Namespace`. The `Pods` are created with a non-existent finalizer.\
@@ -35,6 +35,6 @@ Furthermore we will need to manually remove the finalizer that causes the termin
 > Please remove it manually when you are sure it's not needed anymore. 
 ```shell
 helm uninstall terminating-pod --namespace terminating-pod
-kubectl get pods -n terminating-pod -l demo=terminating-pod -o jsonpath='{.items[*].metadata.name}' | xargs -n 1 -I {} kubectl patch pod {} -n terminating-pod --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
+kubectl get pods -n terminating-pod -l demo=terminating-pod -o jsonpath='{.items[*].metadata.name}' | xargs --max-args=1 | xargs -I {} kubectl patch pod {} -n terminating-pod --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
 kubectl delete namespace terminating-pod
 ```

--- a/terminating-pod/templates/cronjobs.yaml
+++ b/terminating-pod/templates/cronjobs.yaml
@@ -1,12 +1,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: terminating-pod-scale-up
+  name: {{ .Release.Name }}-scale-up
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
-  successfulJobsHistoryLimit: 5
-  schedule: {{ .Values.faultInjection.schedule.scaleUp | quote }}
   jobTemplate:
     spec:
       template:
@@ -18,20 +16,19 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  kubectl scale deployment webserver-deployment --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.max }}
+                  kubectl scale deployment {{ .Values.faultInjection.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.max }}
           restartPolicy: OnFailure
           serviceAccountName: terminating-pod
-
+  schedule: {{ .Values.faultInjection.schedule.scaleUp | quote }}
+  successfulJobsHistoryLimit: 5
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: terminating-pod-scale-down
+  name: {{ .Release.Name }}-scale-down
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
-  successfulJobsHistoryLimit: 5
-  schedule: {{ .Values.faultInjection.schedule.scaleDown | quote }}
   jobTemplate:
     spec:
       template:
@@ -43,25 +40,23 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  kubectl scale deployment webserver-deployment --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.min }}
+                  kubectl scale deployment {{ .Values.faultInjection.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.min }}
           restartPolicy: OnFailure
           serviceAccountName: terminating-pod
+  schedule: {{ .Values.faultInjection.schedule.scaleDown | quote }}
+  successfulJobsHistoryLimit: 5
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: terminating-pod-patch
+  name: {{ .Release.Name }}-patch
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   failedJobsHistoryLimit: 5
-  successfulJobsHistoryLimit: 5
-  schedule: {{ .Values.faultInjection.schedule.patch | quote }}
   jobTemplate:
     spec:
       template:
         spec:
-          restartPolicy: OnFailure
-          serviceAccountName: terminating-pod
           containers:
             - name: patch
               image: bitnami/kubectl:1.23.7
@@ -69,4 +64,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  kubectl get pods --namespace={{ .Release.Namespace }} -l demo=terminating-pod -o=jsonpath='{.items[?(@.metadata.deletionTimestamp)].metadata.name}' | xargs -I {} kubectl patch pod {} --namespace={{ .Release.Namespace }} --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
+                  kubectl get pods --namespace={{ .Release.Namespace }} -l demo={{ .Release.Name }} -o=jsonpath='{.items[?(@.metadata.deletionTimestamp)].metadata.name}' | xargs --max-args=1 | xargs -I {} kubectl patch pod {} --namespace={{ .Release.Namespace }} --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
+          restartPolicy: OnFailure
+          serviceAccountName: terminating-pod
+  schedule: {{ .Values.faultInjection.schedule.patch | quote }}
+  successfulJobsHistoryLimit: 5

--- a/terminating-pod/templates/deployment.yaml
+++ b/terminating-pod/templates/deployment.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webserver-deployment
+  name: {{ .Values.faultInjection.nameOverride }}
   namespace: {{ .Release.Namespace }}
   labels:
-    demo: terminating-pod
+    demo: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.faultInjection.replicas.max }}
   selector:
     matchLabels:
-      demo: terminating-pod
+      demo: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: nginx
-        demo: terminating-pod
+        demo: {{ .Release.Name }}
       finalizers:
       - finalizer.extensions/v1beta1
     spec:
       containers:
-      - name: webserver
+      - name: {{ .Values.faultInjection.nameOverride }}
         image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
         ports:
         - containerPort: 80

--- a/terminating-pod/templates/jobs.yaml
+++ b/terminating-pod/templates/jobs.yaml
@@ -4,13 +4,12 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
-  name: initial-scale-down
+  name: {{ .Release.Name }}-initial-scale-down
   namespace: {{ .Values.faultInjection.namespace }}
 spec:
   backoffLimit: 4
   template:
     spec:
-      serviceAccountName: terminating-pod
       containers:
         - name: scale-down
           image: bitnami/kubectl:latest
@@ -18,5 +17,6 @@ spec:
             - /bin/sh
             - -c
             - |
-              kubectl scale deployment webserver-deployment --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.min }}
+              kubectl scale deployment {{ .Values.faultInjection.nameOverride }} --namespace {{ .Release.Namespace }} --replicas={{ .Values.faultInjection.replicas.min }}
       restartPolicy: OnFailure
+      serviceAccountName: terminating-pod

--- a/terminating-pod/values.yaml
+++ b/terminating-pod/values.yaml
@@ -1,11 +1,12 @@
 faultInjection:
+  nameOverride: slack-service
   namespace: problem-patterns
   replicas:
     min: 2
     max: 3
   schedule:
-    patch: "0 20 * * *" # daily at 20:00
-    scaleUp: "10 20 * * *" # daily at 20:10
+    patch: "40 20 * * *" # daily at 20:00
+    scaleUp: "0 20 * * *" # daily at 20:10
     scaleDown: "20 20 * * *" # daily at 20:20
 
 nginx:


### PR DESCRIPTION
Update helm charts to 1.2.0 with necessary fixes & changes for the live-deployment. 
- added faultInjection.nameOverride
- using Release.Name in many places now to provide more flexibility
- switched to using busybox instead of tomcat in exceeded-quota
- configurations for ingress-nginx added in frequent-restarts
- updated schedules and replicas for multiple demos
- fixed patch cronjob for terminating-pod 
- updated README.md for node-pressure to correctly represent different behaviours for AKS and EKS
- small improvements and unifications across the board